### PR TITLE
Support for Socket Transport

### DIFF
--- a/airbnb.py
+++ b/airbnb.py
@@ -120,7 +120,7 @@ def init():
         config.read(config_file)
         # database
         global DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
-        DB_HOST = config["DATABASE"]["db_host"]
+        DB_HOST = config["DATABASE"]["db_host"] if ("db_host" in config["DATABASE"]) else None
         DB_PORT = config["DATABASE"]["db_port"]
         DB_NAME = config["DATABASE"]["db_name"]
         DB_USER = config["DATABASE"]["db_user"]
@@ -167,21 +167,18 @@ def init():
 def connect():
     """ Return a connection to the database"""
     try:
-        if not hasattr(connect, "conn"):
-            connect.conn = psycopg2.connect(
+        if not hasattr(connect, "conn") or connect.conn is None or connect.conn.closed != 0:
+            cattr = dict(
                 user=DB_USER,
                 password=DB_PASSWORD,
-                host=DB_HOST,
-                port=DB_PORT,
-                database=DB_NAME)
-            connect.conn.set_client_encoding('UTF8')
-        elif connect.conn is None or connect.conn.closed != 0:
-            connect.conn = psycopg2.connect(
-                user=DB_USER,
-                password=DB_PASSWORD,
-                host=DB_HOST,
-                port=DB_PORT,
-                database=DB_NAME)
+                database=DB_NAME
+            )
+            if not DB_HOST == None:
+                cattr.update(dict(
+                            host=DB_HOST,
+                            port=DB_PORT,
+                            ))
+            connect.conn = psycopg2.connect(**cattr)
             connect.conn.set_client_encoding('UTF8')
         return connect.conn
     except psycopg2.OperationalError as pgoe:

--- a/example.config
+++ b/example.config
@@ -6,7 +6,8 @@
 # connection parameters
 
 # The host name on which the database is running
-db_host = <host_name>
+# if none is given (commented out) then socket transport is used
+#db_host = <host_name>
 
 # The port number (PostgreSQL default port is 5432)
 db_port = 5432
@@ -23,7 +24,7 @@ db_password = <password>
 [NETWORK]
 # Network parameters tybe the behaviour of the script
 
-# If you are using a set of proxies, supply a comma-separated list of 
+# If you are using a set of proxies, supply a comma-separated list of
 # host:port pairs here
 proxy_list = host1:port1,host2:port2
 
@@ -47,7 +48,7 @@ http_timeout = 10.0
 fill_max_room_count = 50000
 room_id_upper_bound = 7000000
 
-# Maximum number of pages to loop over in search, 
+# Maximum number of pages to loop over in search,
 # for a given area, room_type, and number of guests
 search_max_pages = 50
 

--- a/postgresql/functions.sql
+++ b/postgresql/functions.sql
@@ -69,7 +69,7 @@ $BODY$
 $BODY$ language sql
 ;
 
-create function add_survey( in varchar(255) ) as
+create function add_survey( in varchar(255) ) RETURNS VOID as
 $BODY$
   insert into survey( survey_description, search_area_id )
     select(name || ' (' || current_date || ')') as survey_description,
@@ -89,22 +89,3 @@ $BODY$
   select "room_id" from "survey_room"(old_survey_id)) 
   as "t"
 $BODY$ language sql
-
-create function trg_location()
-returns trigger
-as
-$trg_location$
-BEGIN
-  NEW.location := st_setsrid(
-  st_makepoint(NEW.longitude, NEW.latitude), 
-  4326
-  );
-  RETURN NEW;
- END
-$trg_location$ language plpgsql;
-
-create trigger trg_location
-before insert or update of latitude, longitude
-on room
-for each row
-execute procedure trg_location();

--- a/postgresql/functions.sql
+++ b/postgresql/functions.sql
@@ -69,7 +69,7 @@ $BODY$
 $BODY$ language sql
 ;
 
-create function add_survey( in varchar(255) ) RETURNS VOID as
+create or replace function add_survey( in varchar(255) ) RETURNS VOID as
 $BODY$
   insert into survey( survey_description, search_area_id )
     select(name || ' (' || current_date || ')') as survey_description,
@@ -79,7 +79,7 @@ $BODY$
 $BODY$ language sql
 ;
 
-create function new_room( in old_survey_id integer, in new_survey_id integer ) 
+create or replace function new_room( in old_survey_id integer, in new_survey_id integer ) 
 returns table ( "room_id" integer ) as
 $BODY$
   select "room_id"


### PR DESCRIPTION
I changed the db-connect function to allow for socket transport. 

Besides I removed the duplicate definiton of trg_location from functions.sql and added a void return to a function - something that seemed to be necessary on psql 9.5.