### PR TITLE
Fixture for export_spreadsheet script

### DIFF
--- a/airbnb_survey.py
+++ b/airbnb_survey.py
@@ -618,7 +618,8 @@ class ABSurveyByBoundingBox(ABSurvey):
                     params["zoom"] = str(True)
                     # params["version"] = "1.4.8"
                     if section_offset > 0:
-                        params["items_offset"] = str(items_offset)
+                        params["items_offset"]   = str(18*items_offset)
+                        params["section_offset"] = str(7)
                     # make the http request
                     response = airbnb_ws.ws_request_with_repeats(
                         self.config, self.config.URL_API_SEARCH_ROOT, params)

--- a/export_spreadsheet.py
+++ b/export_spreadsheet.py
@@ -171,9 +171,9 @@ def export_city_data(ab_config, city, project, format, start_date):
     logging.info(" ---- Surveys: " + ', '.join(str(id) for id in survey_ids))
     conn = ab_config.connect()
 
+    city_view = city_view_name(ab_config, city)
     # survey_ids = [11, ]
     if project == "gis":
-        city_view = city_view_name(ab_config, city)
         sql = """
         select room_id, host_id, room_type,
             borough, neighborhood,
@@ -208,7 +208,8 @@ def export_city_data(ab_config, city, project, format, start_date):
             price, minstay,
             latitude, longitude,
             last_modified as collected
-        from survey_room(%(survey_id)s)
+        from room
+        where survey_id=%(survey_id)s
         order by room_id
         """
 
@@ -222,7 +223,7 @@ def export_city_data(ab_config, city, project, format, start_date):
             csvfile = csvfile.lower()
             df = pd.read_sql(sql, conn,
                              # index_col="room_id",
-                             params={"survey_id": survey_id.item()}
+                             params={"survey_id": survey_id}
                              )
             logging.info("CSV export: survey " +
                          str(survey_id) + " to " + csvfile)
@@ -240,7 +241,7 @@ def export_city_data(ab_config, city, project, format, start_date):
             logging.info("Survey " + str(survey_id) + " for " + city)
             df = pd.read_sql(sql, conn,
                              # index_col="room_id",
-                             params={"survey_id": survey_id.item()}
+                             params={"survey_id": survey_id}
                              )
             if len(df) > 0:
                 logging.info("Survey " + str(survey_id) +


### PR DESCRIPTION
There were two mistakes, both easy to solve:
A typo mistake:
```
Traceback (most recent call last): 
  File "export_spreadsheet.py", line 342, in <module>
    main()
  File "export_spreadsheet.py", line 336, in main
    args.format, args.start_date)
  File "export_spreadsheet.py", line 243, in export_city_data
    params={"survey_id": survey_id.item()}
AttributeError: 'int' object has no attribute 'item'
```

And a non declared variable, moved to wider-scope
```
Traceback (most recent call last):
  File "export_spreadsheet.py", line 343, in <module>
    main()
  File "export_spreadsheet.py", line 337, in main
    args.format, args.start_date)
  File "export_spreadsheet.py", line 280, in export_city_data
    sql += " " + city_view + " li,"
```